### PR TITLE
fix(handle-canonical-updates): Conditionally apply leaf updates directly to the tree.

### DIFF
--- a/src/tree/identity_tree.rs
+++ b/src/tree/identity_tree.rs
@@ -118,6 +118,21 @@ where
         Ok(())
     }
 
+    /// Extends the tree with new leaves and updates the leaves hashmap
+    pub fn extend_from_slice(&mut self, leaves: &[(u32, Hash)]) {
+        // Update the leaves hashmap and collect the new leaf values
+        let leaves = leaves
+            .into_iter()
+            .map(|(idx, hash)| {
+                self.leaves.insert(*hash, *idx);
+                *hash
+            })
+            .collect::<Vec<_>>();
+
+        // Insert the new leaves into the tree
+        self.tree.extend_from_slice(&leaves);
+    }
+
     /// Removes a leaf from the tree and updates the leaves hashmap
     pub fn remove(&mut self, index: usize) {
         let leaf = self.tree.get_leaf(index);

--- a/src/tree/identity_tree.rs
+++ b/src/tree/identity_tree.rs
@@ -122,7 +122,7 @@ where
     pub fn extend_from_slice(&mut self, leaves: &[(u32, Hash)]) {
         // Update the leaves hashmap and collect the new leaf values
         let leaves = leaves
-            .into_iter()
+            .iter()
             .map(|(idx, hash)| {
                 self.leaves.insert(*hash, *idx);
                 *hash

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -373,7 +373,7 @@ where
             self.split_updates_at_canonical_root(identity_updates).await;
 
         // Build the tree from leaves extracted from the canonical updates
-        self.build_canonical_tree(canonical_updates).await;
+        self.build_canonical_tree(canonical_updates).await?;
 
         // Apply any pending updates that have not been bridged to all chains yet
         if !pending_updates.is_empty() {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -111,9 +111,20 @@ where
         Ok(handles)
     }
 
-    /// Spawns a task to handle updates to the canonical tree on mainnet.
     /// All updates are added to `pending_updates` and the mainnet root is updated with the latest root
     fn handle_canonical_updates(
+        &self,
+        leaf_updates_rx: Receiver<(Root, LeafUpdates)>,
+    ) -> JoinHandle<Result<(), WorldTreeError<M>>> {
+        if self.bridged_tree_manager.is_empty() {
+            self.apply_canonical_updates(leaf_updates_rx)
+        } else {
+            self.append_canonical_updates(leaf_updates_rx)
+        }
+    }
+
+    // Appends canonical updates to `tree_updates` as they arrive
+    fn append_canonical_updates(
         &self,
         mut leaf_updates_rx: Receiver<(Root, LeafUpdates)>,
     ) -> JoinHandle<Result<(), WorldTreeError<M>>> {
@@ -121,11 +132,57 @@ where
         let identity_tree = self.identity_tree.clone();
         let chain_state = self.chain_state.clone();
 
+        // If we are monitoring bridged chains, apply canonical updates to tree updates until the root is bridged to all chains
         tokio::spawn(async move {
             while let Some((root, leaf_updates)) = leaf_updates_rx.recv().await
             {
                 let mut identity_tree = identity_tree.write().await;
+
                 identity_tree.append_updates(root, leaf_updates);
+
+                // Update the root for the canonical chain
+                chain_state.write().await.insert(canonical_chain_id, root);
+            }
+
+            Err(WorldTreeError::LeafChannelClosed)
+        })
+    }
+
+    // Applies canonical updates to the tree as they arrive
+    fn apply_canonical_updates(
+        &self,
+        mut leaf_updates_rx: Receiver<(Root, LeafUpdates)>,
+    ) -> JoinHandle<Result<(), WorldTreeError<M>>> {
+        let canonical_chain_id = self.canonical_tree_manager.chain_id;
+        let identity_tree = self.identity_tree.clone();
+        let chain_state: Arc<RwLock<HashMap<u64, Root>>> =
+            self.chain_state.clone();
+
+        tokio::spawn(async move {
+            while let Some((root, leaf_updates)) = leaf_updates_rx.recv().await
+            {
+                match leaf_updates {
+                    LeafUpdates::Insert(leaves) => {
+                        let mut identity_tree = identity_tree.write().await;
+
+                        // Sort the leaf updates by index
+                        let mut leaves = leaves
+                            .into_iter()
+                            .map(|(idx, hash)| (idx.0, hash))
+                            .collect::<Vec<_>>();
+
+                        leaves.sort_by_key(|(idx, _)| *idx);
+
+                        identity_tree.extend_from_slice(&leaves);
+                    }
+                    LeafUpdates::Delete(leaves) => {
+                        let mut identity_tree = identity_tree.write().await;
+
+                        for (leaf_idx, _) in leaves {
+                            identity_tree.remove(leaf_idx.0 as usize);
+                        }
+                    }
+                }
 
                 // Update the root for the canonical chain
                 chain_state.write().await.insert(canonical_chain_id, root);

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -116,9 +116,12 @@ where
         &self,
         leaf_updates_rx: Receiver<(Root, LeafUpdates)>,
     ) -> JoinHandle<Result<(), WorldTreeError<M>>> {
+        // If there are no bridged trees, apply canonical updates to the tree as they arrive
         if self.bridged_tree_manager.is_empty() {
             self.apply_canonical_updates(leaf_updates_rx)
         } else {
+            // Otherwise, append canonical updates to `tree_updates`
+            // which will be applied to the tree once the root is bridged to all chains
             self.append_canonical_updates(leaf_updates_rx)
         }
     }


### PR DESCRIPTION
Previously, leaf updates were being applied to `tree_updates` until a given root had been propagated to all bridged trees. In the cases where the `world-tree` is initialized without any bridged trees, `tree_updates` will continually grow and never be applied to the canonical tree. 

This PR introduces logic to apply leaf updates directly to the tree if we are not monitoring any bridged trees. 