### PR TITLE
fix(config): Update bridge tree deserialization

### DIFF
--- a/bin/world_tree.toml
+++ b/bin/world_tree.toml
@@ -23,8 +23,11 @@ provider.throttle = 150
 window_size = 10000
 
 
+# Note that the following bridged trees are identitified with [bridged_trees.<network>]
+# however this could be any unique identifier, e.g. [bridged_trees.0], [bridged_trees.a], etc.
+
 # OP Mainnet
-[[bridged_trees]]
+[bridged_trees.optimism]
 # Address of the BridgedWorldId contract
 address = "0xB3E7771a6e2d7DD8C0666042B7a07C39b938eb7d"
 # Creation block of the BridgedWorldId contract
@@ -38,7 +41,7 @@ window_size = 10000
 
 
 # Polygon
-[[bridged_trees]]
+[bridged_trees.polygon]
 # Address of the BridgedWorldId contract
 address = "0xa6d85F3b3bE6Ff6DC52C3aaBe9A35d0ce252b79F"
 # Creation block of the BridgedWorldId contract

--- a/src/tree/config.rs
+++ b/src/tree/config.rs
@@ -15,7 +15,7 @@ pub struct ServiceConfig {
     /// Configuration for tree cache
     pub cache: CacheConfig,
     /// Configuration for bridged trees
-    #[serde(with = "vec_map", default)]
+    #[serde(with = "map_vec", default)]
     pub bridged_trees: Vec<TreeConfig>,
     /// Socket at which to serve the service
     #[serde(default = "default::socket_address")]
@@ -109,7 +109,8 @@ mod default {
     }
 }
 
-mod vec_map {
+// Utility functions to convert map to vec
+mod map_vec {
     use std::collections::BTreeMap;
 
     use serde::{Deserialize, Deserializer};
@@ -119,7 +120,7 @@ mod vec_map {
         D: Deserializer<'de>,
         T: Deserialize<'de>,
     {
-        let v: BTreeMap<usize, T> = Deserialize::deserialize(deserializer)?;
+        let v: BTreeMap<String, T> = Deserialize::deserialize(deserializer)?;
 
         Ok(v.into_values().collect())
     }


### PR DESCRIPTION
When attempting to run `world-tree --config <config.toml>`, the following error is produced.

```
Error: invalid type: sequence, expected a map

Location:
    src/tree/config.rs:52:22
```

This is due to a change introduced in [2f5aa2c](https://github.com/worldcoin/world-tree/commit/2f5aa2cc040b43fe4ccdec845ba9594112d0b10a).

This PR updates the world tree configuration de-serialization for bridged trees to fix the issue.