### PR TITLE
feat: include path information if config parsing fails.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6489,6 +6489,7 @@ dependencies = [
  "semaphore",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "take_mut",
  "telemetry-batteries",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ semaphore = { git = "https://github.com/worldcoin/semaphore-rs", rev = "60a313d7
 ] }
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0"
+serde_path_to_error = "0.1.16"
 take_mut = "0.2.2"
 telemetry-batteries = { git = "https://github.com/worldcoin/telemetry-batteries.git", rev = "802a4f39f358e077b11c8429b4c65f3e45b85959" }
 thiserror = "1.0"

--- a/src/tree/config.rs
+++ b/src/tree/config.rs
@@ -49,7 +49,7 @@ impl ServiceConfig {
             )
             .build()?;
 
-        let config = settings.try_deserialize::<Self>()?;
+        let config = serde_path_to_error::deserialize(settings)?;
 
         Ok(config)
     }


### PR DESCRIPTION
If there is an problem with parting config file, the error message does not give information about context of the error, that is in which option/path there is a problem.

Example of an error befor this commit:

> Error: relative URL without a base
>
> Location:
>     src/tree/config.rs:52:22

After commit

> Error: bridged_trees.optimism.provider.rpc_endpoint: relative URL without a base
>
> Location:
>     src/tree/config.rs:52:22

After the commit you could see which config option deserializer did not like.

