### PR TITLE
send spans for inclusion proof at 'info' loglevel [PRO-590]

### DIFF
--- a/src/tree/service.rs
+++ b/src/tree/service.rs
@@ -106,7 +106,7 @@ pub struct ChainIdQueryParams {
     chain_id: Option<ChainId>,
 }
 
-#[tracing::instrument(level = "debug", skip(world_tree))]
+#[tracing::instrument(skip(world_tree))]
 pub async fn inclusion_proof<M: Middleware + 'static>(
     State(world_tree): State<Arc<WorldTree<M>>>,
     Query(query_params): Query<ChainIdQueryParams>,


### PR DESCRIPTION
I want to add time spent on inclusion_proof to the dashboard. `world-tree` does send that trace, but with `debug` loglevel which does not reach datadog. Increase loglevel to `info` so i could see the span id datadog.