### PR TITLE
Add default text propagator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6482,6 +6482,8 @@ dependencies = [
  "hex",
  "hyper",
  "metrics 0.21.1",
+ "opentelemetry",
+ "opentelemetry-datadog",
  "rand",
  "rayon",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ governor = "0.6.0"
 hex = "0.4"
 hyper = { version = "^0.14.27", features = ["server", "tcp", "http1", "http2"] }
 metrics = "0.21.1"
+opentelemetry = "0.21.0"
+opentelemetry-datadog = "0.9.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rayon = "1.10.0"
 ruint = "1.11.0"

--- a/bin/world_tree.rs
+++ b/bin/world_tree.rs
@@ -7,6 +7,8 @@ use ethers::providers::{Http, Provider};
 use ethers_throttle::ThrottledJsonRpcClient;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
+use opentelemetry;
+use opentelemetry_datadog::DatadogPropagator;
 use telemetry_batteries::metrics::statsd::StatsdBattery;
 use telemetry_batteries::tracing::datadog::DatadogBattery;
 use telemetry_batteries::tracing::TracingShutdownHandle;
@@ -36,6 +38,7 @@ pub async fn main() -> eyre::Result<()> {
     let config = ServiceConfig::load(opts.config.as_deref())?;
 
     let _tracing_shutdown_handle = if let Some(telemetry) = &config.telemetry {
+        opentelemetry::global::set_text_map_propagator(DatadogPropagator::new());
         let tracing_shutdown_handle = DatadogBattery::init(
             telemetry.traces_endpoint.as_deref(),
             &telemetry.service_name,


### PR DESCRIPTION
Datadog does not show parent tracing spans for world-tree service, initialize global text propagator to fix that.

P.S. not tested.