### PR TITLE
fix(status-codes): Update status codes `WorldTreeError` and `IdentityTreeError`

### DIFF
--- a/load-test/loadTest.js
+++ b/load-test/loadTest.js
@@ -162,7 +162,7 @@ const identityCommitments = new SharedArray('identityCommitments', function () {
     "0x25c37cc5bb4f6b754e22282f621c4b498c3b9075cd3cdd4784f93a0e81c64ea9",
     "0x06c9177cf96e954c24bb3723d6002d6f33924c11e52cd75009e9e4414f14aa9c",
     "0x12cf4475a0dee711f3979426bec56c8aa883282874fce0d97464c0939011a841"
-];
+  ];
 });
 
 
@@ -171,7 +171,7 @@ const baseEndpoint = __ENV.TREE_AVAILABILITY_SERVICE_ENDPOINT;
 if (!baseEndpoint) {
   throw new Error('Base endpoint not specified. Use -e TREE_AVAILABILITY_SERVICE_ENDPOINT=your_endpoint');
 }
-const endpoint = `${baseEndpoint}/inclusionProof?chainId=1`;
+const endpoint = `${baseEndpoint}/inclusionProof`;
 
 export default function () {
   const identityCommitment = identityCommitments[Math.floor(Math.random() * identityCommitments.length)];

--- a/src/tree/error.rs
+++ b/src/tree/error.rs
@@ -57,7 +57,15 @@ pub enum IdentityTreeError {
 
 impl IdentityTreeError {
     fn to_status_code(&self) -> StatusCode {
-        todo!()
+        match self {
+            IdentityTreeError::RootNotFound
+            | IdentityTreeError::LeafNotFound => StatusCode::NOT_FOUND,
+            IdentityTreeError::MmapVecError(_)
+            | IdentityTreeError::IoError(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            IdentityTreeError::LeafAlreadyExists => StatusCode::CONFLICT,
+        }
     }
 }
 
@@ -66,7 +74,11 @@ where
     M: Middleware + 'static,
 {
     fn to_status_code(&self) -> StatusCode {
-        todo!()
+        match self {
+            WorldTreeError::TreeNotSynced => StatusCode::SERVICE_UNAVAILABLE,
+            WorldTreeError::IdentityTreeError(e) => e.to_status_code(),
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        }
     }
 }
 

--- a/src/tree/error.rs
+++ b/src/tree/error.rs
@@ -47,10 +47,18 @@ pub enum IdentityTreeError {
     RootNotFound,
     #[error("Leaf already exists")]
     LeafAlreadyExists,
+    #[error("Leaf does not exist in tree")]
+    LeafNotFound,
     #[error(transparent)]
     MmapVecError(#[from] eyre::Report),
     #[error(transparent)]
     IoError(#[from] std::io::Error),
+}
+
+impl IdentityTreeError {
+    fn to_status_code(&self) -> StatusCode {
+        todo!()
+    }
 }
 
 impl<M> WorldTreeError<M>
@@ -58,7 +66,7 @@ where
     M: Middleware + 'static,
 {
     fn to_status_code(&self) -> StatusCode {
-        StatusCode::INTERNAL_SERVER_ERROR
+        todo!()
     }
 }
 

--- a/src/tree/error.rs
+++ b/src/tree/error.rs
@@ -60,11 +60,7 @@ impl IdentityTreeError {
         match self {
             IdentityTreeError::RootNotFound
             | IdentityTreeError::LeafNotFound => StatusCode::NOT_FOUND,
-            IdentityTreeError::MmapVecError(_)
-            | IdentityTreeError::IoError(_) => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            IdentityTreeError::LeafAlreadyExists => StatusCode::CONFLICT,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/src/tree/identity_tree.rs
+++ b/src/tree/identity_tree.rs
@@ -345,7 +345,7 @@ where
     ) -> Result<Option<InclusionProof>, IdentityTreeError> {
         let leaf_idx = match self.leaves.get(&leaf) {
             Some(idx) => idx,
-            None => return Ok(None),
+            None => return Err(IdentityTreeError::LeafNotFound),
         };
 
         if let Some(root) = root {


### PR DESCRIPTION
This PR updates status codes for error types to return `404` when an inclusion proof is requested for a leaf or root that is not found.

```rust

impl IdentityTreeError {
    fn to_status_code(&self) -> StatusCode {
        match self {
            IdentityTreeError::RootNotFound
            | IdentityTreeError::LeafNotFound => StatusCode::NOT_FOUND,
            _ => StatusCode::INTERNAL_SERVER_ERROR,
        }
    }
}

impl<M> WorldTreeError<M>
where
    M: Middleware + 'static,
{
    fn to_status_code(&self) -> StatusCode {
        match self {
            WorldTreeError::TreeNotSynced => StatusCode::SERVICE_UNAVAILABLE,
            WorldTreeError::IdentityTreeError(e) => e.to_status_code(),
            _ => StatusCode::INTERNAL_SERVER_ERROR,
        }
    }
}
```