### PR TITLE
feat(tree-cache): Auto purge invalid cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6494,6 +6494,7 @@ dependencies = [
  "serde_path_to_error",
  "take_mut",
  "telemetry-batteries",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde_json = "1.0"
 serde_path_to_error = "0.1.16"
 take_mut = "0.2.2"
 telemetry-batteries = { git = "https://github.com/worldcoin/telemetry-batteries.git", rev = "802a4f39f358e077b11c8429b4c65f3e45b85959" }
+tempfile = "3.10.1"
 thiserror = "1.0"
 tokio = { version = "1.34.0", features = ["sync", "macros", "rt-multi-thread"] }
 toml = "0.8"

--- a/bin/world_tree.rs
+++ b/bin/world_tree.rs
@@ -7,7 +7,6 @@ use ethers::providers::{Http, Provider};
 use ethers_throttle::ThrottledJsonRpcClient;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use opentelemetry;
 use opentelemetry_datadog::DatadogPropagator;
 use telemetry_batteries::metrics::statsd::StatsdBattery;
 use telemetry_batteries::tracing::datadog::DatadogBattery;


### PR DESCRIPTION
This PR introduces logic to auto purge tree cache if it is invalid and create a new cache file.

```rust
pub fn new_with_cache(
        depth: usize,
        file_path: PathBuf,
    ) -> Result<Self, IdentityTreeError> {
     // --snip--
     
            let tree = match CascadingMerkleTree::<PoseidonHash, _>::restore(
                mmap_vec,
                depth,
                &Hash::ZERO,
            ) {
                Ok(tree) => tree,
                Err(_) => {
                    tracing::error!(
                        "Failed to restore tree from cache, purging cache and creating new tree"
                    );

                    // Remove the existing cache and create a new cache file
                    fs::remove_file(&file_path)?;
                    let mmap_vec = unsafe { MmapVec::open_create(file_path)? };

                    CascadingMerkleTree::<PoseidonHash, _>::new(
                        mmap_vec,
                        depth,
                        &Hash::ZERO,
                    )
                }
            };

        // --snip--
        };
```