### PR TITLE
feat(health): Update `/health` endpoint to return chain state.

### DIFF
--- a/src/tree/identity_tree.rs
+++ b/src/tree/identity_tree.rs
@@ -9,7 +9,7 @@ use semaphore::generic_storage::{GenericStorage, MmapVec};
 use semaphore::merkle_tree::{Branch, Hasher};
 use semaphore::poseidon_tree::{PoseidonHash, Proof};
 use semaphore::Field;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::error::IdentityTreeError;
 use super::{Hash, LeafIndex, NodeIndex};
@@ -514,7 +514,7 @@ pub fn storage_idx_to_coords(index: usize) -> (usize, usize) {
     (depth as usize, offset)
 }
 
-#[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
+#[derive(PartialEq, Serialize, Deserialize, Eq, Hash, Clone, Copy, Debug)]
 pub struct Root {
     pub hash: Hash,
     //NOTE: note that this assumes that there is only one wallet that sequences transactions

--- a/src/tree/service.rs
+++ b/src/tree/service.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use tokio::task::JoinHandle;
 
 use super::error::WorldTreeError;
+use super::identity_tree::Root;
 use super::{ChainId, Hash, InclusionProof, WorldTree};
 
 /// Service that keeps the World Tree synced with `WorldIDIdentityManager` and exposes an API endpoint to serve inclusion proofs for a given World ID.
@@ -126,15 +127,11 @@ pub struct TreeStatus {}
 #[tracing::instrument(level = "debug", skip(world_tree))]
 pub async fn health<M: Middleware + 'static>(
     State(world_tree): State<Arc<WorldTree<M>>>,
-) -> Result<(StatusCode, Json<HashMap<u64, Hash>>), WorldTreeError<M>> {
-    let mut tree_status = HashMap::new();
-
-    let chain_state = world_tree.chain_state.read().await.clone();
-    for (chain_id, root) in chain_state {
-        tree_status.insert(chain_id, root.hash);
-    }
-
-    Ok((StatusCode::OK, Json(tree_status)))
+) -> Result<(StatusCode, Json<HashMap<u64, Root>>), WorldTreeError<M>> {
+    Ok((
+        StatusCode::OK,
+        Json(world_tree.chain_state.read().await.clone()),
+    ))
 }
 
 #[tracing::instrument(level = "debug", skip(world_tree))]

--- a/src/tree/service.rs
+++ b/src/tree/service.rs
@@ -51,7 +51,7 @@ where
         let router = axum::Router::new()
             .route("/inclusionProof", axum::routing::post(inclusion_proof))
             .route("/computeRoot", axum::routing::post(compute_root))
-            .route("/health", axum::routing::get(health))
+            .route("/health", axum::routing::post(health))
             .layer(middleware::from_fn(logging::middleware))
             .with_state(self.world_tree.clone());
 
@@ -122,16 +122,13 @@ pub async fn inclusion_proof<M: Middleware + 'static>(
     Ok((StatusCode::OK, Json(inclusion_proof)))
 }
 
-pub struct TreeStatus {}
-
 #[tracing::instrument(level = "debug", skip(world_tree))]
+#[allow(clippy::complexity)]
 pub async fn health<M: Middleware + 'static>(
     State(world_tree): State<Arc<WorldTree<M>>>,
 ) -> Result<(StatusCode, Json<HashMap<u64, Root>>), WorldTreeError<M>> {
-    Ok((
-        StatusCode::OK,
-        Json(world_tree.chain_state.read().await.clone()),
-    ))
+    let chain_state = world_tree.chain_state.read().await.clone();
+    Ok((StatusCode::OK, Json(chain_state)))
 }
 
 #[tracing::instrument(level = "debug", skip(world_tree))]

--- a/src/tree/service.rs
+++ b/src/tree/service.rs
@@ -126,9 +126,9 @@ pub async fn inclusion_proof<M: Middleware + 'static>(
 #[allow(clippy::complexity)]
 pub async fn health<M: Middleware + 'static>(
     State(world_tree): State<Arc<WorldTree<M>>>,
-) -> Result<(StatusCode, Json<HashMap<u64, Root>>), WorldTreeError<M>> {
+) -> Result<Json<HashMap<u64, Root>>, WorldTreeError<M>> {
     let chain_state = world_tree.chain_state.read().await.clone();
-    Ok((StatusCode::OK, Json(chain_state)))
+    Ok(Json(chain_state))
 }
 
 #[tracing::instrument(level = "debug", skip(world_tree))]


### PR DESCRIPTION
This PR updates the `/health` endpoint to return the latest root on each chain represented as a `HashMap<u64, Root>`. 

```rust
pub async fn health<M: Middleware + 'static>(
    State(world_tree): State<Arc<WorldTree<M>>>,
) -> Result<(StatusCode, Json<HashMap<u64, Root>>), WorldTreeError<M>> {
    let chain_state = world_tree.chain_state.read().await.clone();
    Ok((StatusCode::OK, Json(chain_state)))
}
```