### PR TITLE
Remove `cancel_tx` and cleanup containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 ips.toml
 .env
 tree-cache
+bin/world_tree.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -452,6 +452,12 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.0",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -472,7 +478,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -492,9 +498,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -506,7 +512,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tokio",
  "tower",
  "tower-layer",
@@ -522,8 +528,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -537,7 +543,7 @@ dependencies = [
  "axum",
  "bytes",
  "futures-util",
- "hyper",
+ "hyper 0.14.28",
  "telemetry-batteries",
  "tracing",
 ]
@@ -574,6 +580,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -656,6 +668,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-named-pipe",
+ "hyper-rustls 0.26.0",
+ "hyper-util",
+ "hyperlocal-next",
+ "log",
+ "pin-project-lite",
+ "rustls 0.22.4",
+ "rustls-native-certs",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.44.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
 ]
 
 [[package]]
@@ -817,6 +879,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.5",
 ]
@@ -888,7 +951,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -900,7 +963,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -908,6 +971,10 @@ name = "clap_lex"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "client"
+version = "0.1.0"
 
 [[package]]
 name = "coins-bip32"
@@ -1406,7 +1473,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "strsim 0.10.0",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1417,7 +1485,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1456,6 +1524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1553,6 +1622,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31951f49556e34d90ed28342e1df7e1cb7a229c4cab0aecc627b5d91edd41d07"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -1648,7 +1728,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1689,7 +1769,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1841,10 +1921,10 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.59",
+ "syn 2.0.68",
  "toml",
  "walkdir",
 ]
@@ -1862,7 +1942,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1888,7 +1968,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.59",
+ "syn 2.0.68",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -1929,7 +2009,7 @@ checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
 dependencies = [
  "chrono",
  "ethers-core 2.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest",
+ "reqwest 0.11.27",
  "semver 1.0.22",
  "serde",
  "serde_json",
@@ -1954,7 +2034,7 @@ dependencies = [
  "futures-locks",
  "futures-util",
  "instant",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror",
@@ -1982,12 +2062,12 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hashers",
- "http",
+ "http 0.2.12",
  "instant",
  "jsonwebtoken",
  "once_cell",
  "pin-project",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror",
@@ -2248,7 +2328,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2399,7 +2479,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -2505,6 +2604,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
+name = "hickory-proto"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2523,10 +2667,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -2540,7 +2706,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -2566,9 +2755,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2581,17 +2770,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.3.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
- "rustls",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "rustls 0.21.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "log",
+ "rustls 0.22.4",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "rustls 0.23.10",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -2601,10 +2861,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "hyperlocal-next"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2635,6 +2946,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "idna"
@@ -2709,6 +3030,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -2727,6 +3049,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-sys 0.48.0",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -2969,6 +3303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2985,6 +3328,12 @@ checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -3072,8 +3421,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
 dependencies = [
  "base64 0.21.7",
- "hyper",
- "hyper-tls",
+ "hyper 0.14.28",
+ "hyper-tls 0.5.0",
  "indexmap 2.2.6",
  "ipnet",
  "metrics 0.22.3",
@@ -3103,7 +3452,7 @@ checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3356,7 +3705,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3446,7 +3795,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3490,7 +3839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e09667367cb509f10d7cf5960a83f9c4d96e93715f750b164b4b98d46c3cbf4"
 dependencies = [
  "futures-core",
- "http",
+ "http 0.2.12",
  "indexmap 2.2.6",
  "itertools 0.11.0",
  "once_cell",
@@ -3498,7 +3847,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "reqwest",
+ "reqwest 0.11.27",
  "rmp",
  "thiserror",
  "url",
@@ -3512,9 +3861,9 @@ checksum = "7f51189ce8be654f9b5f7e70e49967ed894e84a06fc35c6c042e64ac1fc5399e"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 0.2.12",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.11.27",
 ]
 
 [[package]]
@@ -3641,6 +3990,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax 0.8.3",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax 0.8.3",
+ "structmeta",
+ "syn 2.0.68",
+]
+
+[[package]]
 name = "password-hash"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3737,7 +4111,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3801,7 +4175,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3839,7 +4213,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3929,7 +4303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
 dependencies = [
  "proc-macro2",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4000,9 +4374,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -4057,6 +4431,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -4248,12 +4628,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-rustls 0.24.2",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -4262,23 +4642,76 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.10",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.5",
+ "hickory-resolver",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-rustls 0.27.2",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.1.2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.52.0",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname",
+ "quick-error",
 ]
 
 [[package]]
@@ -4502,8 +4935,48 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4516,12 +4989,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -4684,7 +5184,7 @@ dependencies = [
  "once_cell",
  "rand",
  "rayon",
- "reqwest",
+ "reqwest 0.11.27",
  "ruint",
  "semaphore-depth-config",
  "semaphore-depth-macros",
@@ -4710,7 +5210,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semaphore-depth-config",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4788,7 +5288,7 @@ checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4813,6 +5313,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4831,6 +5342,36 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4872,6 +5413,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -5011,9 +5561,38 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.68",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
 
 [[package]]
 name = "strum"
@@ -5034,7 +5613,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5053,7 +5632,7 @@ dependencies = [
  "fs2",
  "hex",
  "once_cell",
- "reqwest",
+ "reqwest 0.11.27",
  "semver 1.0.22",
  "serde",
  "serde_json",
@@ -5076,9 +5655,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.59"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5090,6 +5669,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "sysctl"
@@ -5151,7 +5736,7 @@ source = "git+https://github.com/worldcoin/telemetry-batteries.git?rev=802a4f39f
 dependencies = [
  "chrono",
  "dirs",
- "http",
+ "http 0.2.12",
  "metrics 0.22.3",
  "metrics-exporter-prometheus",
  "metrics-exporter-statsd",
@@ -5160,7 +5745,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry_sdk",
  "rand",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror",
@@ -5196,6 +5781,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "testcontainers"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2c9b71635ab25d4f789a86678d114a4f390467c8b93fd7feeaf7c443732a511"
+dependencies = [
+ "async-trait",
+ "bollard",
+ "bollard-stubs",
+ "bytes",
+ "dirs",
+ "docker_credential",
+ "either",
+ "futures",
+ "log",
+ "memchr",
+ "parse-display",
+ "reqwest 0.12.5",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5206,22 +5819,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5311,6 +5924,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
@@ -5324,7 +5938,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5343,7 +5957,29 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.10",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -5367,10 +6003,10 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
- "rustls",
+ "rustls 0.21.10",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tungstenite",
  "webpki-roots",
 ]
@@ -5516,7 +6152,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5645,12 +6281,12 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "native-tls",
  "rand",
- "rustls",
+ "rustls 0.21.10",
  "sha1",
  "thiserror",
  "url",
@@ -5745,8 +6381,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -5847,7 +6484,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
  "wasm-bindgen-shared",
 ]
 
@@ -5881,7 +6518,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6464,6 +7101,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "world-tree"
 version = "0.1.0"
 dependencies = [
@@ -6480,13 +7127,13 @@ dependencies = [
  "futures",
  "governor",
  "hex",
- "hyper",
+ "hyper 0.14.28",
  "metrics 0.21.1",
  "opentelemetry",
  "opentelemetry-datadog",
  "rand",
  "rayon",
- "reqwest",
+ "reqwest 0.11.27",
  "ruint",
  "semaphore",
  "serde",
@@ -6495,6 +7142,7 @@ dependencies = [
  "take_mut",
  "telemetry-batteries",
  "tempfile",
+ "testcontainers",
  "thiserror",
  "tokio",
  "toml",
@@ -6563,7 +7211,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6583,7 +7231,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.68",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,9 @@ tracing-subscriber = "0.3.18"
 url = "2.5.0"
 
 [dev-dependencies]
+tokio = { version = "1.34.0", features = ["sync", "macros", "rt-multi-thread", "process"] }
 reqwest = { version = "0.11.22", features = ["json"] }
+testcontainers = "0.18.0"
 
 [[bin]]
 name = "world-tree"

--- a/bin/world_tree.rs
+++ b/bin/world_tree.rs
@@ -1,10 +1,6 @@
-use std::fs;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use clap::Parser;
-use ethers::providers::{Http, Provider};
-use ethers_throttle::ThrottledJsonRpcClient;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use opentelemetry_datadog::DatadogPropagator;
@@ -13,10 +9,9 @@ use telemetry_batteries::tracing::datadog::DatadogBattery;
 use telemetry_batteries::tracing::TracingShutdownHandle;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
+use world_tree::init_world_tree;
 use world_tree::tree::config::ServiceConfig;
 use world_tree::tree::service::InclusionProofService;
-use world_tree::tree::tree_manager::{BridgedTree, CanonicalTree, TreeManager};
-use world_tree::tree::WorldTree;
 
 /// This service syncs the state of the World Tree and spawns a server that can deliver inclusion proofs for a given identity.
 #[derive(Parser, Debug)]
@@ -67,11 +62,10 @@ pub async fn main() -> eyre::Result<()> {
 
     tracing::info!(?config, "Starting World Tree service");
 
-    let world_tree = initialize_world_tree(&config).await?;
+    let world_tree = init_world_tree(&config).await?;
 
-    let handles = InclusionProofService::new(world_tree)
-        .serve(config.socket_address)
-        .await?;
+    let service = InclusionProofService::new(world_tree);
+    let handles = service.serve(config.socket_address).await?;
 
     let mut handles = handles.into_iter().collect::<FuturesUnordered<_>>();
     while let Some(result) = handles.next().await {
@@ -80,65 +74,4 @@ pub async fn main() -> eyre::Result<()> {
     }
 
     Ok(())
-}
-
-async fn initialize_world_tree(
-    config: &ServiceConfig,
-) -> eyre::Result<Arc<WorldTree<Provider<ThrottledJsonRpcClient<Http>>>>> {
-    let canonical_provider_config = &config.canonical_tree.provider;
-
-    let http_provider =
-        Http::new(canonical_provider_config.rpc_endpoint.clone());
-    let throttled_provider = ThrottledJsonRpcClient::new(
-        http_provider,
-        canonical_provider_config.throttle,
-        None,
-    );
-    let canonical_middleware = Arc::new(Provider::new(throttled_provider));
-
-    let canonical_tree_config = &config.canonical_tree;
-    let canonical_tree_manager = TreeManager::<_, CanonicalTree>::new(
-        canonical_tree_config.address,
-        canonical_tree_config.window_size,
-        canonical_tree_config.creation_block,
-        canonical_middleware,
-    )
-    .await?;
-
-    let mut bridged_tree_managers = vec![];
-
-    for tree_config in config.bridged_trees.iter() {
-        let bridged_provider_config = &tree_config.provider;
-        let http_provider =
-            Http::new(bridged_provider_config.rpc_endpoint.clone());
-
-        let throttled_provider = ThrottledJsonRpcClient::new(
-            http_provider,
-            bridged_provider_config.throttle,
-            None,
-        );
-        let bridged_middleware = Arc::new(Provider::new(throttled_provider));
-
-        let tree_manager = TreeManager::<_, BridgedTree>::new(
-            tree_config.address,
-            tree_config.window_size,
-            tree_config.creation_block,
-            bridged_middleware,
-        )
-        .await?;
-
-        bridged_tree_managers.push(tree_manager);
-    }
-
-    if config.cache.purge_cache {
-        tracing::info!("Purging tree cache");
-        fs::remove_file(&config.cache.cache_file)?;
-    }
-
-    Ok(Arc::new(WorldTree::new(
-        config.tree_depth,
-        canonical_tree_manager,
-        bridged_tree_managers,
-        &config.cache.cache_file,
-    )?))
 }

--- a/bin/world_tree.toml
+++ b/bin/world_tree.toml
@@ -16,7 +16,7 @@ address = "0xf7134CE138832c1456F2a91D64621eE90c2bddEa"
 # Creation block of the WorldIdIdentityManager contract
 creation_block = 17636832
 # RPC endpoint
-provider.rpc_endpoint = ""
+provider.rpc_endpoint = "https://eth-mainnet.g.alchemy.com/v2/JVsc_pPRnVj5rHuoQZFMV4ETAVulp9Ry"
 # Requests per second throttle
 provider.throttle = 150
 # Blockscanner window size; the maximum number of blocks to query at a time
@@ -33,25 +33,25 @@ address = "0xB3E7771a6e2d7DD8C0666042B7a07C39b938eb7d"
 # Creation block of the BridgedWorldId contract
 creation_block = 109906421
 # RPC endpoint
-provider.rpc_endpoint = ""
+provider.rpc_endpoint = "https://opt-mainnet.g.alchemy.com/v2/JVsc_pPRnVj5rHuoQZFMV4ETAVulp9Ry"
 # Requests per second throttle
 provider.throttle = 150
 # Blockscanner window size; the maximum number of blocks to query at a time
 window_size = 10000
 
 
-# Polygon
-[bridged_trees.polygon]
-# Address of the BridgedWorldId contract
-address = "0xa6d85F3b3bE6Ff6DC52C3aaBe9A35d0ce252b79F"
-# Creation block of the BridgedWorldId contract
-creation_block = 47860919
-# RPC endpoint
-provider.rpc_endpoint = ""
-# Requests per second throttle
-provider.throttle = 150
-# Blockscanner window size; the maximum number of blocks to query at a time
-window_size = 10000
+# # Polygon
+# [bridged_trees.polygon]
+# # Address of the BridgedWorldId contract
+# address = "0xa6d85F3b3bE6Ff6DC52C3aaBe9A35d0ce252b79F"
+# # Creation block of the BridgedWorldId contract
+# creation_block = 47860919
+# # RPC endpoint
+# provider.rpc_endpoint = ""
+# # Requests per second throttle
+# provider.throttle = 150
+# # Blockscanner window size; the maximum number of blocks to query at a time
+# window_size = 10000
 
 
 # [telemetry]

--- a/bin/world_tree.toml
+++ b/bin/world_tree.toml
@@ -16,7 +16,7 @@ address = "0xf7134CE138832c1456F2a91D64621eE90c2bddEa"
 # Creation block of the WorldIdIdentityManager contract
 creation_block = 17636832
 # RPC endpoint
-provider.rpc_endpoint = "https://eth-mainnet.g.alchemy.com/v2/JVsc_pPRnVj5rHuoQZFMV4ETAVulp9Ry"
+provider.rpc_endpoint = ""
 # Requests per second throttle
 provider.throttle = 150
 # Blockscanner window size; the maximum number of blocks to query at a time
@@ -33,25 +33,12 @@ address = "0xB3E7771a6e2d7DD8C0666042B7a07C39b938eb7d"
 # Creation block of the BridgedWorldId contract
 creation_block = 109906421
 # RPC endpoint
-provider.rpc_endpoint = "https://opt-mainnet.g.alchemy.com/v2/JVsc_pPRnVj5rHuoQZFMV4ETAVulp9Ry"
+provider.rpc_endpoint = ""
 # Requests per second throttle
 provider.throttle = 150
 # Blockscanner window size; the maximum number of blocks to query at a time
 window_size = 10000
 
-
-# # Polygon
-# [bridged_trees.polygon]
-# # Address of the BridgedWorldId contract
-# address = "0xa6d85F3b3bE6Ff6DC52C3aaBe9A35d0ce252b79F"
-# # Creation block of the BridgedWorldId contract
-# creation_block = 47860919
-# # RPC endpoint
-# provider.rpc_endpoint = ""
-# # Requests per second throttle
-# provider.throttle = 150
-# # Blockscanner window size; the maximum number of blocks to query at a time
-# window_size = 10000
 
 
 # [telemetry]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "client"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -15,6 +15,6 @@ abigen!(
         function latestRoot() public view virtual returns (uint256)
         function receiveRoot(uint256 newRoot) external
     ]"#,
-    event_derives(serde::Deserialize, serde::Serialize)
 
+    event_derives(serde::Deserialize, serde::Serialize)
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,74 @@
+use std::fs;
+use std::sync::Arc;
+
+use ethers::providers::{Http, Provider};
+use ethers_throttle::ThrottledJsonRpcClient;
+use tree::config::ServiceConfig;
+use tree::tree_manager::{BridgedTree, CanonicalTree, TreeManager};
+use tree::WorldTree;
+
 pub mod abi;
 mod error;
 pub mod serde_utils;
 pub mod tree;
+
+pub async fn init_world_tree(
+    config: &ServiceConfig,
+) -> eyre::Result<Arc<WorldTree<Provider<ThrottledJsonRpcClient<Http>>>>> {
+    let canonical_provider_config = &config.canonical_tree.provider;
+
+    let http_provider =
+        Http::new(canonical_provider_config.rpc_endpoint.clone());
+    let throttled_provider = ThrottledJsonRpcClient::new(
+        http_provider,
+        canonical_provider_config.throttle,
+        None,
+    );
+    let canonical_middleware = Arc::new(Provider::new(throttled_provider));
+
+    let canonical_tree_config = &config.canonical_tree;
+    let canonical_tree_manager = TreeManager::<_, CanonicalTree>::new(
+        canonical_tree_config.address,
+        canonical_tree_config.window_size,
+        canonical_tree_config.creation_block,
+        canonical_middleware,
+    )
+    .await?;
+
+    let mut bridged_tree_managers = vec![];
+
+    for tree_config in config.bridged_trees.iter() {
+        let bridged_provider_config = &tree_config.provider;
+        let http_provider =
+            Http::new(bridged_provider_config.rpc_endpoint.clone());
+
+        let throttled_provider = ThrottledJsonRpcClient::new(
+            http_provider,
+            bridged_provider_config.throttle,
+            None,
+        );
+        let bridged_middleware = Arc::new(Provider::new(throttled_provider));
+
+        let tree_manager = TreeManager::<_, BridgedTree>::new(
+            tree_config.address,
+            tree_config.window_size,
+            tree_config.creation_block,
+            bridged_middleware,
+        )
+        .await?;
+
+        bridged_tree_managers.push(tree_manager);
+    }
+
+    if config.cache.purge_cache {
+        tracing::info!("Purging tree cache");
+        fs::remove_file(&config.cache.cache_file)?;
+    }
+
+    Ok(Arc::new(WorldTree::new(
+        config.tree_depth,
+        canonical_tree_manager,
+        bridged_tree_managers,
+        &config.cache.cache_file,
+    )?))
+}

--- a/src/tree/identity_tree.rs
+++ b/src/tree/identity_tree.rs
@@ -369,6 +369,12 @@ where
 
         if let Some(root) = root {
             if root.hash == self.tree.root() {
+                // FIXME: This code is duplicate of what's in the else branch of the
+                //        outer if statement
+                if *leaf_idx as usize >= self.tree.num_leaves() {
+                    return Ok(None);
+                }
+
                 let proof = self.tree.proof(*leaf_idx as usize);
                 Ok(Some(InclusionProof::new(self.tree.root(), proof)))
             } else {
@@ -376,7 +382,7 @@ where
                 Ok(Some(InclusionProof::new(root.hash, proof)))
             }
         } else {
-            if *leaf_idx as usize > self.tree.num_leaves() {
+            if *leaf_idx as usize >= self.tree.num_leaves() {
                 return Ok(None);
             }
 
@@ -484,6 +490,7 @@ pub fn flatten_leaf_updates(
     updates
 }
 
+#[derive(Debug, Clone)]
 pub enum LeafUpdates {
     Insert(Leaves),
     Delete(Leaves),

--- a/src/tree/identity_tree.rs
+++ b/src/tree/identity_tree.rs
@@ -534,7 +534,7 @@ impl PartialOrd for Root {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InclusionProof {
     pub root: Field,
@@ -859,10 +859,7 @@ mod test {
             );
 
         // Collect the second half of the leaves
-        let leaf_updates = leaves[(NUM_LEAVES / 2)..]
-            .iter()
-            .cloned()
-            .collect::<Vec<Hash>>();
+        let leaf_updates = leaves[(NUM_LEAVES / 2)..].to_vec();
 
         let updated_root = identity_tree.compute_root(&leaf_updates, None)?;
         let expected_root = expected_tree.root();

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -19,7 +19,7 @@ use semaphore::lazy_merkle_tree::LazyMerkleTree;
 use semaphore::merkle_tree::Hasher;
 use semaphore::poseidon_tree::PoseidonHash;
 use tokio::sync::mpsc::Receiver;
-use tokio::sync::{broadcast, RwLock};
+use tokio::sync::{RwLock};
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use tracing::instrument;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -19,7 +19,7 @@ use semaphore::lazy_merkle_tree::LazyMerkleTree;
 use semaphore::merkle_tree::Hasher;
 use semaphore::poseidon_tree::PoseidonHash;
 use tokio::sync::mpsc::Receiver;
-use tokio::sync::{RwLock};
+use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use tracing::instrument;

--- a/src/tree/newtypes.rs
+++ b/src/tree/newtypes.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+use std::ops::{Deref, DerefMut};
+
+macro_rules! primitive_newtype {
+    (pub struct $outer:ident($tname:ty)) => {
+        #[derive(
+            Debug,
+            Clone,
+            Copy,
+            Serialize,
+            PartialEq,
+            Eq,
+            PartialOrd,
+            Ord,
+            Hash,
+            Deserialize,
+        )]
+        pub struct $outer(pub $tname);
+
+        impl std::fmt::Display for $outer {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl Deref for $outer {
+            type Target = $tname;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl DerefMut for $outer {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+        impl From<$tname> for $outer {
+            fn from(value: $tname) -> Self {
+                $outer(value)
+            }
+        }
+
+        impl From<$outer> for $tname {
+            fn from(value: $outer) -> Self {
+                value.0
+            }
+        }
+
+        impl From<&$outer> for $tname {
+            fn from(value: &$outer) -> Self {
+                value.0
+            }
+        }
+    };
+}
+
+primitive_newtype!(pub struct ChainId(u64));
+primitive_newtype!(pub struct NodeIndex(u32));
+primitive_newtype!(pub struct LeafIndex(u32));

--- a/src/tree/newtypes.rs
+++ b/src/tree/newtypes.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
+
+use serde::{Deserialize, Serialize};
 
 macro_rules! primitive_newtype {
     (pub struct $outer:ident($tname:ty)) => {

--- a/src/tree/service.rs
+++ b/src/tree/service.rs
@@ -8,6 +8,7 @@ use axum::{middleware, Json};
 use axum_middleware::logging;
 use ethers::providers::Middleware;
 use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
 use super::error::WorldTreeError;
@@ -19,6 +20,7 @@ use super::{ChainId, Hash, InclusionProof, WorldTree};
 pub struct InclusionProofService<M: Middleware + 'static> {
     /// In-memory representation of the merkle tree containing all verified World IDs.
     pub world_tree: Arc<WorldTree<M>>,
+    pub cancel_tx: broadcast::Sender<()>,
 }
 
 impl<M> InclusionProofService<M>
@@ -26,7 +28,12 @@ where
     M: Middleware,
 {
     pub fn new(world_tree: Arc<WorldTree<M>>) -> Self {
-        Self { world_tree }
+        let (cancel_tx, _) = broadcast::channel(1);
+
+        Self {
+            world_tree,
+            cancel_tx,
+        }
     }
 
     /// Spawns an axum server and exposes an API endpoint to serve inclusion proofs for requested identity commitments.
@@ -43,6 +50,29 @@ where
         self,
         addr: SocketAddr,
     ) -> eyre::Result<Vec<JoinHandle<Result<(), WorldTreeError<M>>>>> {
+        let (_local_addr, handles) = self.bind_serve(addr).await?;
+
+        Ok(handles)
+    }
+
+    /// Spawns an axum server and exposes an API endpoint to serve inclusion proofs for requested identity commitments.
+    /// This function spawns a task to sync and maintain the state of the world tree across all monitored chains.
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` - Socket address to bind the server to
+    ///
+    /// # Returns
+    ///
+    /// The socket address the server is bound to.
+    /// Vector of `JoinHandle`s for the spawned tasks.
+    pub async fn bind_serve(
+        self,
+        addr: SocketAddr,
+    ) -> eyre::Result<(
+        SocketAddr,
+        Vec<JoinHandle<Result<(), WorldTreeError<M>>>>,
+    )> {
         let mut handles = vec![];
 
         // Initialize a new router and spawn the server
@@ -55,10 +85,17 @@ where
             .layer(middleware::from_fn(logging::middleware))
             .with_state(self.world_tree.clone());
 
+        let bound_server = axum::Server::bind(&addr);
+        let local_addr = bound_server.local_addr();
+
+        let mut cancel_rx = self.cancel_tx.subscribe();
         let server_handle = tokio::spawn(async move {
             tracing::info!("Spawning server");
-            axum::Server::bind(&addr)
+            bound_server
                 .serve(router.into_make_service())
+                .with_graceful_shutdown(async move {
+                    cancel_rx.recv().await.ok();
+                })
                 .await?;
 
             Ok(())
@@ -66,11 +103,11 @@ where
 
         // Spawn a task to sync and maintain the state of the world tree
         tracing::info!("Spawning world tree");
-        handles.extend(self.world_tree.spawn().await?);
+        handles.extend(self.world_tree.spawn(self.cancel_tx.clone()).await?);
 
         handles.push(server_handle);
 
-        Ok(handles)
+        Ok((local_addr, handles))
     }
 }
 

--- a/src/tree/service.rs
+++ b/src/tree/service.rs
@@ -8,7 +8,7 @@ use axum::{middleware, Json};
 use axum_middleware::logging;
 use ethers::providers::Middleware;
 use serde::{Deserialize, Serialize};
-use tokio::sync::broadcast;
+
 use tokio::task::JoinHandle;
 
 use super::error::WorldTreeError;

--- a/src/tree/service.rs
+++ b/src/tree/service.rs
@@ -8,7 +8,6 @@ use axum::{middleware, Json};
 use axum_middleware::logging;
 use ethers::providers::Middleware;
 use serde::{Deserialize, Serialize};
-
 use tokio::task::JoinHandle;
 
 use super::error::WorldTreeError;

--- a/src/tree/tree_manager.rs
+++ b/src/tree/tree_manager.rs
@@ -137,7 +137,7 @@ impl TreeVersion for CanonicalTree {
                     .await?;
 
                     for update in identity_updates {
-                        tracing::info!(?chain_id, new_root = ?update.0.hash, "Canonical root updated");
+                        tracing::info!(?chain_id, ?new_root, "Root updated");
                         tx.send(update).await?;
                     }
 
@@ -199,11 +199,7 @@ impl TreeVersion for BridgedTree {
                             RootAddedFilter::decode_log(&RawLog::from(log))?;
                         let new_root = Hash::from_limbs(data.root.0);
 
-                        tracing::info!(
-                            ?chain_id,
-                            ?new_root,
-                            "Bridged root updated"
-                        );
+                        tracing::info!(?chain_id, ?new_root, "Root updated");
                         tx.send((chain_id, new_root)).await?;
                     }
                     ok(false)

--- a/src/tree/tree_manager.rs
+++ b/src/tree/tree_manager.rs
@@ -9,7 +9,7 @@ use ethers::providers::Middleware;
 use ethers::types::{Filter, Log, Selector, ValueOrArray, H160, H256, U256};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use tokio::sync::broadcast;
+
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 

--- a/src/tree/tree_manager.rs
+++ b/src/tree/tree_manager.rs
@@ -31,7 +31,6 @@ pub trait TreeVersion: Default {
     fn spawn<M: Middleware + 'static>(
         tx: Sender<Self::ChannelData>,
         block_scanner: Arc<BlockScanner<M>>,
-        cancel_rx: broadcast::Receiver<()>,
     ) -> JoinHandle<Result<(), WorldTreeError<M>>>;
 
     fn tree_changed_signature() -> H256;
@@ -87,9 +86,8 @@ where
     pub fn spawn(
         &self,
         tx: Sender<T::ChannelData>,
-        cancel_rx: broadcast::Receiver<()>,
     ) -> JoinHandle<Result<(), WorldTreeError<M>>> {
-        T::spawn(tx, self.block_scanner.clone(), cancel_rx)
+        T::spawn(tx, self.block_scanner.clone())
     }
 }
 
@@ -101,7 +99,6 @@ impl TreeVersion for CanonicalTree {
     fn spawn<M: Middleware + 'static>(
         tx: Sender<Self::ChannelData>,
         block_scanner: Arc<BlockScanner<M>>,
-        mut cancel_rx: broadcast::Receiver<()>,
     ) -> JoinHandle<Result<(), WorldTreeError<M>>> {
         tokio::spawn(async move {
             let chain_id = block_scanner
@@ -110,16 +107,9 @@ impl TreeVersion for CanonicalTree {
                 .await
                 .map_err(WorldTreeError::MiddlewareError)?
                 .as_u64();
-
             loop {
-                let res = async {
-                    let logs = tokio::select! {
-                        logs = block_scanner.next() => logs?,
-                        _ = cancel_rx.recv() => {
-                            tracing::info!("Received cancel signal");
-                            return ok(true)
-                        },
-                    };
+                async {
+                    let logs = block_scanner.next().await?;
 
                     if logs.is_empty() {
                         tokio::time::sleep(Duration::from_secs(
@@ -127,7 +117,7 @@ impl TreeVersion for CanonicalTree {
                         ))
                         .await;
 
-                        return ok(false);
+                        return ok(());
                     }
 
                     let identity_updates = extract_identity_updates(
@@ -137,21 +127,14 @@ impl TreeVersion for CanonicalTree {
                     .await?;
 
                     for update in identity_updates {
-                        tracing::info!(?chain_id, ?new_root, "Root updated");
+                        tracing::info!(?chain_id, new_root = ?update.0.hash, "Root updated");
                         tx.send(update).await?;
                     }
-
-                    ok(false)
+                    ok(())
                 }
                 .await
                 .log();
-
-                if res == Some(true) {
-                    break;
-                }
             }
-
-            Ok(())
         })
     }
 
@@ -167,7 +150,6 @@ impl TreeVersion for BridgedTree {
     fn spawn<M: Middleware + 'static>(
         tx: Sender<Self::ChannelData>,
         block_scanner: Arc<BlockScanner<M>>,
-        mut cancel_rx: broadcast::Receiver<()>,
     ) -> JoinHandle<Result<(), WorldTreeError<M>>> {
         tokio::spawn(async move {
             let chain_id = block_scanner
@@ -178,19 +160,15 @@ impl TreeVersion for BridgedTree {
                 .as_u64();
 
             loop {
-                let res = async {
-                    let logs = tokio::select! {
-                        logs = block_scanner.next() => logs?,
-                        _ = cancel_rx.recv() => return ok(true),
-                    };
-
+                async {
+                    let logs = block_scanner.next().await?;
                     if logs.is_empty() {
                         tokio::time::sleep(Duration::from_secs(
                             BLOCK_SCANNER_SLEEP_TIME,
                         ))
                         .await;
 
-                        return ok(false);
+                        return ok(());
                     }
 
                     for log in logs {
@@ -202,17 +180,11 @@ impl TreeVersion for BridgedTree {
                         tracing::info!(?chain_id, ?new_root, "Root updated");
                         tx.send((chain_id, new_root)).await?;
                     }
-                    ok(false)
+                    ok(())
                 }
                 .await
                 .log();
-
-                if res == Some(true) {
-                    break;
-                }
             }
-
-            Ok(())
         })
     }
 

--- a/src/tree/tree_manager.rs
+++ b/src/tree/tree_manager.rs
@@ -137,7 +137,7 @@ impl TreeVersion for CanonicalTree {
                     .await?;
 
                     for update in identity_updates {
-                        tracing::info!(?chain_id, new_root = ?update.0.hash, "Root updated");
+                        tracing::info!(?chain_id, new_root = ?update.0.hash, "Canonical root updated");
                         tx.send(update).await?;
                     }
 
@@ -199,7 +199,11 @@ impl TreeVersion for BridgedTree {
                             RootAddedFilter::decode_log(&RawLog::from(log))?;
                         let new_root = Hash::from_limbs(data.root.0);
 
-                        tracing::info!(?chain_id, ?new_root, "Root updated");
+                        tracing::info!(
+                            ?chain_id,
+                            ?new_root,
+                            "Bridged root updated"
+                        );
                         tx.send((chain_id, new_root)).await?;
                     }
                     ok(false)

--- a/src/tree/tree_manager.rs
+++ b/src/tree/tree_manager.rs
@@ -9,7 +9,6 @@ use ethers::providers::Middleware;
 use ethers::types::{Filter, Log, Selector, ValueOrArray, H160, H256, U256};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 

--- a/tests/fixtures/integration_contracts/.gitignore
+++ b/tests/fixtures/integration_contracts/.gitignore
@@ -1,0 +1,14 @@
+# Compiler files
+cache/
+out/
+
+# Ignores development broadcast logs
+!/broadcast
+/broadcast/*/31337/
+/broadcast/**/dry-run/
+
+# Docs
+docs/
+
+# Dotenv file
+.env

--- a/tests/fixtures/integration_contracts/foundry.toml
+++ b/tests/fixtures/integration_contracts/foundry.toml
@@ -1,0 +1,3 @@
+[profile.default]
+src = "src"
+out = "out"

--- a/tests/fixtures/integration_contracts/runMainnet.sh
+++ b/tests/fixtures/integration_contracts/runMainnet.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+# Start Anvil in the background
+anvil --host 0.0.0.0 &
+
+ANVIL_PID=$!
+PRIV_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+# Create WorldIDIdentityManager
+# Expected address: 0x5FbDB2315678afecb367f032d93F642f64180aa3
+forge create --private-key $PRIV_KEY WorldIDIdentityManager
+
+# Wait for anvil to finish
+wait $ANVIL_PID

--- a/tests/fixtures/integration_contracts/runMainnet.sh
+++ b/tests/fixtures/integration_contracts/runMainnet.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # Start Anvil in the background
-anvil --host 0.0.0.0 &
+anvil --chain-id 31337 --block-time 2 --host 0.0.0.0 &
 
 ANVIL_PID=$!
 PRIV_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

--- a/tests/fixtures/integration_contracts/runRollup.sh
+++ b/tests/fixtures/integration_contracts/runRollup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+# Start Anvil in the background
+anvil --host 0.0.0.0 &
+
+ANVIL_PID=$!
+PRIV_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+# Create BridgedWorldID
+# Expected address: 0x5FbDB2315678afecb367f032d93F642f64180aa3
+forge create --private-key $PRIV_KEY BridgedWorldID
+
+# Wait for anvil to finish
+wait $ANVIL_PID

--- a/tests/fixtures/integration_contracts/runRollup.sh
+++ b/tests/fixtures/integration_contracts/runRollup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # Start Anvil in the background
-anvil --host 0.0.0.0 &
+anvil --chain-id 31338 --block-time 2 --host 0.0.0.0 &
 
 ANVIL_PID=$!
 PRIV_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

--- a/tests/fixtures/integration_contracts/src/BridgedWorldID.sol
+++ b/tests/fixtures/integration_contracts/src/BridgedWorldID.sol
@@ -11,6 +11,8 @@ contract BridgedWorldID {
     }
 
     function receiveRoot(uint256 newRoot) external {
+        _latestRoot = newRoot;
+
         emit RootAdded(newRoot, uint128(block.timestamp));
     }
 }

--- a/tests/fixtures/integration_contracts/src/BridgedWorldID.sol
+++ b/tests/fixtures/integration_contracts/src/BridgedWorldID.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract BridgedWorldID {
+    event RootAdded(uint256 root, uint128 timestamp);
+
+    uint256 _latestRoot = 0x2134e76ac5d21aab186c2be1dd8f84ee880a1e46eaf712f9d371b6df22191f3e;
+
+    function latestRoot() public view virtual returns (uint256) {
+        return _latestRoot;
+    }
+
+    function receiveRoot(uint256 newRoot) external {
+        emit RootAdded(newRoot, uint128(block.timestamp));
+    }
+}

--- a/tests/fixtures/integration_contracts/src/BridgedWorldID.sol
+++ b/tests/fixtures/integration_contracts/src/BridgedWorldID.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.19;
 contract BridgedWorldID {
     event RootAdded(uint256 root, uint128 timestamp);
 
+    // Initial root for depth 20
     uint256 _latestRoot = 0x2134e76ac5d21aab186c2be1dd8f84ee880a1e46eaf712f9d371b6df22191f3e;
 
     function latestRoot() public view virtual returns (uint256) {

--- a/tests/fixtures/integration_contracts/src/WorldIDIdentityManager.sol
+++ b/tests/fixtures/integration_contracts/src/WorldIDIdentityManager.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract WorldIDIdentityManager {
+    uint256 _latestRoot = 0x2134e76ac5d21aab186c2be1dd8f84ee880a1e46eaf712f9d371b6df22191f3e;
+
+    event TreeChanged(
+        uint256 indexed preRoot,
+        uint8 indexed kind,
+        uint256 indexed postRoot
+    );
+
+    function latestRoot() external view returns (uint256) {
+        return _latestRoot;
+    }
+
+    function registerIdentities(
+        uint256[8] calldata /* insertionProof */,
+        uint256 preRoot,
+        uint32 /* startIndex */,
+        uint256[] calldata /* identityCommitments */,
+        uint256 postRoot
+    ) external {
+        emit TreeChanged(preRoot, 0, postRoot);
+    }
+
+    function deleteIdentities(
+        uint256[8] calldata /* deletionProof */,
+        bytes calldata /* packedDeletionIndices */,
+        uint256 preRoot,
+        uint256 postRoot
+    ) external {
+        emit TreeChanged(preRoot, 1, postRoot);
+    }
+}

--- a/tests/fixtures/integration_contracts/src/WorldIDIdentityManager.sol
+++ b/tests/fixtures/integration_contracts/src/WorldIDIdentityManager.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.19;
 
 contract WorldIDIdentityManager {
+    // Initial root for depth 20
     uint256 _latestRoot = 0x2134e76ac5d21aab186c2be1dd8f84ee880a1e46eaf712f9d371b6df22191f3e;
 
     event TreeChanged(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -324,17 +324,22 @@ async fn integration() -> eyre::Result<()> {
         handle.abort();
     }
 
+    tracing::info!("Shutting down mainnet container...");
+    mainnet_container.stop().await?;
+    tracing::info!("Shutting down rollup container...");
+    rollup_container.stop().await?;
+
     Ok(())
 }
 
 async fn setup_world_tree(
     config: &ServiceConfig,
 ) -> eyre::Result<
-    (Vec<
+    Vec<
         JoinHandle<
             Result<(), WorldTreeError<Provider<ThrottledJsonRpcClient<Http>>>>,
         >,
-    >),
+    >,
 > {
     let world_tree = init_world_tree(config).await?;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,4 @@
-use std::net::{TcpListener};
+use std::net::TcpListener;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,7 +18,6 @@ use test_client::TestClient;
 use testcontainers::core::{ContainerPort, Mount};
 use testcontainers::runners::AsyncRunner;
 use testcontainers::{ContainerAsync, GenericImage, ImageExt};
-
 use tokio::task::JoinHandle;
 use world_tree::abi::{IBridgedWorldID, IWorldIDIdentityManager};
 use world_tree::init_world_tree;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,4 @@
-use std::net::{SocketAddr, TcpListener};
+use std::net::{TcpListener};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,7 +18,7 @@ use test_client::TestClient;
 use testcontainers::core::{ContainerPort, Mount};
 use testcontainers::runners::AsyncRunner;
 use testcontainers::{ContainerAsync, GenericImage, ImageExt};
-use tokio::sync::broadcast;
+
 use tokio::task::JoinHandle;
 use world_tree::abi::{IBridgedWorldID, IWorldIDIdentityManager};
 use world_tree::init_world_tree;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,265 @@
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ethers::middleware::SignerMiddleware;
+use ethers::providers::{Http, Middleware, Provider};
+use ethers::signers::{LocalWallet, Signer};
+use ethers::types::{Address, U256};
+use ethers_throttle::ThrottledJsonRpcClient;
+use eyre::ContextCompat;
+use rand::Rng;
+use semaphore::cascading_merkle_tree::CascadingMerkleTree;
+use semaphore::poseidon_tree::PoseidonHash;
+use semaphore::Field;
+use tempfile::NamedTempFile;
+use test_client::TestClient;
+use testcontainers::core::{ContainerPort, Mount};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, GenericImage, ImageExt};
+use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
+use world_tree::abi::IWorldIDIdentityManager;
+use world_tree::init_world_tree;
+use world_tree::tree::config::{
+    CacheConfig, ProviderConfig, ServiceConfig, TreeConfig,
+};
+use world_tree::tree::error::WorldTreeError;
+use world_tree::tree::service::InclusionProofService;
+
+const TREE_DEPTH: usize = 20;
+
+mod test_client;
+
+#[tokio::test]
+async fn integration() -> eyre::Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let cache_file = NamedTempFile::new()?;
+
+    let mainnet_container = setup_mainnet().await?;
+    let mainnet_rpc_port = mainnet_container.get_host_port_ipv4(8545).await?;
+    let mainnet_rpc_url = format!("http://127.0.0.1:{}", mainnet_rpc_port);
+
+    let rollup_container = setup_rollup().await?;
+    let _rollup_rpc_port = rollup_container.get_host_port_ipv4(8545).await?;
+    let rollup_rpc_url = format!("http://127.0.0.1:{}", mainnet_rpc_port);
+
+    let mut tree = CascadingMerkleTree::<PoseidonHash, _>::new(
+        vec![],
+        TREE_DEPTH,
+        &Field::ZERO,
+    );
+
+    let initial_root = tree.root();
+    tracing::info!(?initial_root, "Initial root",);
+
+    // The addresses are the same since we use the same account on both networks
+    let id_manager_address: Address =
+        "0x5FbDB2315678afecb367f032d93F642f64180aa3".parse()?;
+    let bridged_address: Address =
+        "0x5FbDB2315678afecb367f032d93F642f64180aa3".parse()?;
+
+    let mainnet_provider = Provider::<Http>::new(mainnet_rpc_url.parse()?);
+    let rollup_provider = Provider::<Http>::new(rollup_rpc_url.parse()?);
+
+    tracing::info!("Waiting for contracts to deploy...");
+    wait_until_contracts_deployed(&mainnet_provider, bridged_address).await?;
+
+    let mainnet_chain_id = mainnet_provider.get_chainid().await?;
+    let rollup_chain_id = rollup_provider.get_chainid().await?;
+
+    let wallet = LocalWallet::from_str(
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+    )?;
+    let mainnet_wallet =
+        wallet.clone().with_chain_id(mainnet_chain_id.as_u64());
+    let rollup_wallet = wallet.with_chain_id(rollup_chain_id.as_u64());
+
+    let mainnet_signer =
+        SignerMiddleware::new(mainnet_provider, mainnet_wallet);
+    let mainnet_signer = Arc::new(mainnet_signer);
+
+    let rollup_signer = SignerMiddleware::new(rollup_provider, rollup_wallet);
+    let rollup_signer = Arc::new(rollup_signer);
+
+    let first_batch = random_leaves(5);
+
+    let world_id_manager = IWorldIDIdentityManager::new(
+        id_manager_address,
+        mainnet_signer.clone(),
+    );
+
+    let _bridged_world_id =
+        IWorldIDIdentityManager::new(bridged_address, rollup_signer.clone());
+
+    tree.extend_from_slice(&first_batch);
+
+    let first_batch_root = tree.root();
+
+    tracing::info!("Latest root = {:?}", world_id_manager.latest_root().await?);
+
+    // We need some initial test data to start
+    world_id_manager
+        .register_identities(
+            [U256::zero(); 8],
+            f2ethers(initial_root), // pre root,
+            0,                      // start index
+            first_batch.iter().cloned().map(f2ethers).collect(), // commitments
+            f2ethers(first_batch_root), // post root
+        )
+        .send()
+        .await?;
+
+    tracing::info!("Latest root = {:?}", world_id_manager.latest_root().await?);
+
+    tracing::info!("Setting up world-tree service");
+    let (world_tree_socket_addr, cancel_tx, handles) =
+        setup_world_tree(&ServiceConfig {
+            tree_depth: TREE_DEPTH,
+            canonical_tree: TreeConfig {
+                address: id_manager_address,
+                window_size: 10,
+                creation_block: 0,
+                provider: ProviderConfig {
+                    rpc_endpoint: mainnet_rpc_url.parse()?,
+                    throttle: 150,
+                },
+            },
+            cache: CacheConfig {
+                cache_file: cache_file.path().to_path_buf(),
+                purge_cache: true,
+            },
+            bridged_trees: vec![TreeConfig {
+                address: bridged_address,
+                window_size: 10,
+                creation_block: 0,
+                provider: ProviderConfig {
+                    rpc_endpoint: rollup_rpc_url.parse()?,
+                    throttle: 150,
+                },
+            }],
+            socket_address: ([127, 0, 0, 1], 0).into(),
+            telemetry: None,
+        })
+        .await?;
+
+    let client = TestClient::new(format!("http://{world_tree_socket_addr}"));
+
+    let ip = client.inclusion_proof(&first_batch[0]).await?;
+    tracing::info!(?ip, "Got first inclusion proof!");
+
+    assert_eq!(
+        ip.root, first_batch_root,
+        "First inclusion proof root should batch to first batch"
+    );
+
+    tokio::time::sleep(Duration::from_secs_f32(1.0)).await;
+
+    tracing::info!("Cancelling world-tree service");
+    cancel_tx.send(())?;
+
+    tracing::info!("Waiting for world-tree service to shutdown...");
+    for handle in handles {
+        // Ignore errors - channels might close causing recv errors at exit
+        let _ = handle.await?;
+    }
+
+    Ok(())
+}
+
+async fn setup_world_tree(
+    config: &ServiceConfig,
+) -> eyre::Result<(
+    SocketAddr,
+    broadcast::Sender<()>,
+    Vec<
+        JoinHandle<
+            Result<(), WorldTreeError<Provider<ThrottledJsonRpcClient<Http>>>>,
+        >,
+    >,
+)> {
+    let world_tree = init_world_tree(config).await?;
+
+    let service = InclusionProofService::new(world_tree);
+    let cancel_tx = service.cancel_tx.clone();
+
+    let (socket_addr, handles) =
+        service.bind_serve(config.socket_address).await?;
+
+    Ok((socket_addr, cancel_tx, handles))
+}
+
+async fn setup_mainnet() -> eyre::Result<ContainerAsync<GenericImage>> {
+    setup_chain("runMainnet.sh").await
+}
+
+async fn setup_rollup() -> eyre::Result<ContainerAsync<GenericImage>> {
+    setup_chain("runRollup.sh").await
+}
+
+async fn setup_chain(
+    script_file: &str,
+) -> eyre::Result<ContainerAsync<GenericImage>> {
+    let current_path = std::env::current_dir()?;
+    let mount_dir = current_path.join("tests/fixtures/integration_contracts");
+    let mount_dir = mount_dir.canonicalize()?;
+    let mount_dir = mount_dir.to_str().context("Invalid path")?;
+
+    let container = GenericImage::new("ghcr.io/foundry-rs/foundry", "latest")
+        .with_entrypoint("/bin/sh")
+        .with_exposed_port(ContainerPort::Tcp(8545))
+        .with_mount(Mount::bind_mount(mount_dir, "/app"))
+        .with_cmd(["-c", &format!("cd /app; ./{script_file}")])
+        .start()
+        .await?;
+
+    Ok(container)
+}
+
+async fn wait_until_contracts_deployed(
+    provider: &Provider<Http>,
+    address: Address,
+) -> eyre::Result<()> {
+    const MAX_RETRIES: usize = 10;
+    const SLEEP_DURATION: Duration = Duration::from_secs(1);
+
+    for _ in 0..MAX_RETRIES {
+        let resp = provider.get_code(address, None).await;
+
+        match resp {
+            Ok(code) if !code.is_empty() => return Ok(()),
+            Ok(_) => {
+                tracing::warn!("Contracts not deployed yet");
+            }
+            Err(err) => {
+                tracing::warn!(%err, err_debug = ?err, "Failed to get code");
+            }
+        }
+
+        tokio::time::sleep(SLEEP_DURATION).await;
+    }
+
+    eyre::bail!("Contracts not deployed")
+}
+
+fn random_leaves(n: usize) -> Vec<Field> {
+    let mut rng = rand::thread_rng();
+
+    (0..n)
+        .map(|_| {
+            let mut limbs = [0u64; 4];
+
+            limbs[0] = rng.gen();
+            limbs[1] = rng.gen();
+            limbs[2] = rng.gen();
+
+            Field::from_limbs(limbs)
+        })
+        .collect()
+}
+
+fn f2ethers(f: Field) -> U256 {
+    U256::from_little_endian(&f.as_le_bytes())
+}

--- a/tests/test_client/mod.rs
+++ b/tests/test_client/mod.rs
@@ -37,7 +37,6 @@ impl TestClient {
             response.error_for_status_ref()?;
         }
 
-
         Ok(response.json().await?)
     }
 

--- a/tests/test_client/mod.rs
+++ b/tests/test_client/mod.rs
@@ -1,0 +1,55 @@
+use semaphore::Field;
+use world_tree::tree::identity_tree::InclusionProof;
+use world_tree::tree::service::InclusionProofRequest;
+
+pub struct TestClient {
+    pub client: reqwest::Client,
+    pub world_tree_host: String,
+}
+
+impl TestClient {
+    pub fn new(world_tree_host: String) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            world_tree_host,
+        }
+    }
+
+    pub async fn inclusion_proof(
+        &self,
+        commitment: &Field,
+    ) -> eyre::Result<InclusionProof> {
+        let url = format!("{}/inclusionProof", self.world_tree_host);
+
+        let response = self
+            .client
+            .post(&url)
+            .json(&InclusionProofRequest {
+                identity_commitment: *commitment,
+            })
+            .send()
+            .await?;
+
+        response.error_for_status_ref()?;
+
+        Ok(response.json().await?)
+    }
+
+    // pub async fn inclusion_proof_by_chain_id(
+    //     &self,
+    //     commitment: &Field,
+    // ) -> eyre::Result<InclusionProof> {
+    //     let url = format!("{}/inclusionProof", self.world_tree_host);
+
+    //     let response = self
+    //         .client
+    //         .post(&url)
+    //         .json(&serde_json::json!({ "identity_commitment": commitment }))
+    //         .send()
+    //         .await?;
+
+    //     response.error_for_status_ref()?;
+
+    //     Ok(response.json().await?)
+    // }
+}


### PR DESCRIPTION
This PR removes the `cancel_tx` channel from the `InclusionProofService` and `WorldTree`. Logic was also added to clean up containers after running integration tests.