### PR TITLE
Graceful Shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2811,6 +2811,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7225,6 +7241,7 @@ dependencies = [
  "governor",
  "hex",
  "hex-literal",
+ "humantime-serde",
  "hyper 0.14.30",
  "indicatif",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ alloy = { version = "0.3", features = [
     "transports",
     "hyper",
     "signer-local",
-    "signers"
+    "signers",
 ] }
 eyre = "0.6"
 futures = "0.3"
@@ -42,6 +42,7 @@ semaphore = { git = "https://github.com/worldcoin/semaphore-rs", rev = "59b2a0af
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0"
 serde_path_to_error = "0.1.16"
+humantime-serde = "1.1.1"
 take_mut = "0.2.2"
 telemetry-batteries = { git = "https://github.com/worldcoin/telemetry-batteries.git", rev = "12cc036234b4e9b86f22ff7e35d499e2ff1e6304" }
 tempfile = "3.10.1"

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,3 +1,66 @@
+use std::time::Duration;
+
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use tokio::task::{JoinError, JoinHandle};
+use tracing::info;
+
 pub mod ingest;
 pub mod observe;
 pub mod update;
+
+pub async fn monitor_tasks(
+    mut handles: FuturesUnordered<JoinHandle<()>>,
+    shutdown_delay: Duration,
+) -> Result<(), JoinError> {
+    while let Some(result) = handles.next().await {
+        if let Err(error) = result {
+            tracing::error!(?error, "Task panicked");
+            // abort all other tasks
+            for handle in handles.iter() {
+                handle.abort();
+            }
+            info!("All tasks aborted");
+            // Give tasks a few seconds to get to an await point
+            tokio::time::sleep(shutdown_delay).await;
+            return Err(error);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::time::Instant;
+    use tokio::time::sleep;
+
+    #[tokio::test]
+    async fn test_monitor_tasks() {
+        let shutdown_delay = Duration::from_millis(100);
+
+        let panic_handle = tokio::spawn(async {
+            panic!("Task failed");
+        });
+
+        let return_handle = tokio::spawn(async {});
+
+        let run_time = Duration::from_millis(100);
+        let run_handle = tokio::spawn(async {
+            sleep(Duration::from_secs(1)).await;
+        });
+
+        let handles = FuturesUnordered::from_iter([
+            panic_handle,
+            return_handle,
+            run_handle,
+        ]);
+
+        let start = Instant::now();
+        assert!(monitor_tasks(handles, shutdown_delay).await.is_err());
+
+        let elapsed = start.elapsed();
+        assert!(elapsed >= shutdown_delay);
+        assert!(elapsed <= shutdown_delay + run_time);
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use alloy::primitives::{Address, U256};
 use alloy::providers::Provider;
 use eyre::ContextCompat;
+use futures::stream::FuturesUnordered;
 use rand::Rng;
 use semaphore::Field;
 use testcontainers::core::{ContainerPort, Mount};
@@ -56,7 +57,7 @@ macro_rules! attempt_async {
 
 pub async fn setup_world_tree(
     config: &ServiceConfig,
-) -> WorldTreeResult<(SocketAddr, Vec<JoinHandle<()>>)> {
+) -> WorldTreeResult<(SocketAddr, FuturesUnordered<JoinHandle<()>>)> {
     let world_tree = init_world_tree(config).await?;
 
     let service = InclusionProofService::new(world_tree);

--- a/tests/empty_start.rs
+++ b/tests/empty_start.rs
@@ -136,6 +136,7 @@ async fn empty_start() -> WorldTreeResult<()> {
         }],
         socket_address: None,
         telemetry: None,
+        shutdown_delay: Duration::from_secs(1),
     };
 
     let (local_addr, handles) = setup_world_tree(&service_config).await?;

--- a/tests/full_flow.rs
+++ b/tests/full_flow.rs
@@ -168,6 +168,7 @@ async fn full_flow() -> WorldTreeResult<()> {
         }],
         socket_address: None,
         telemetry: None,
+        shutdown_delay: Duration::from_secs(1),
     };
 
     let (local_addr, handles) = setup_world_tree(&service_config).await?;

--- a/tests/many_batches.rs
+++ b/tests/many_batches.rs
@@ -139,6 +139,7 @@ async fn many_batches() -> WorldTreeResult<()> {
         }],
         socket_address: None,
         telemetry: None,
+        shutdown_delay: Duration::from_secs(1),
     };
 
     let (local_addr, handles) = setup_world_tree(&service_config).await?;

--- a/tests/missed_event_on_bridged.rs
+++ b/tests/missed_event_on_bridged.rs
@@ -142,6 +142,7 @@ async fn missing_event_on_bridged() -> WorldTreeResult<()> {
         }],
         socket_address: None,
         telemetry: None,
+        shutdown_delay: Duration::from_secs(1),
     };
 
     let (local_addr, handles) = setup_world_tree(&service_config).await?;


### PR DESCRIPTION
Cancels spawned tasks on shutdown rather than exiting early from `main`. We then have a shutdown delay which gives tasks a few seconds to reach an await before exiting. Should prevent mmap cache corruption.