### PR TITLE
feat: lag block scanner stream behind finality

### DIFF
--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -31,9 +31,11 @@ pub async fn monitor_tasks(
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use std::time::Instant;
+
     use tokio::time::sleep;
+
+    use super::*;
 
     #[tokio::test]
     async fn test_monitor_tasks() {

--- a/src/tree/block_scanner.rs
+++ b/src/tree/block_scanner.rs
@@ -70,16 +70,27 @@ where
                     // Update the latest block number only if required
                     if try_to > latest {
                         let provider = self.provider.clone();
-                        latest = retry(
+                        let finalized = retry(
                             Duration::from_millis(100),
                             Some(Duration::from_secs(60)),
                             move || {
                                 let provider = provider.clone();
-                                async move { provider.get_block_number().await }
+                                async move {
+                                    provider
+                                        .get_block_by_number(
+                                            BlockNumberOrTag::Finalized,
+                                            false,
+                                        )
+                                        .await
+                                }
                             },
                         )
                         .await
-                        .expect("failed to fetch latest block after retry");
+                        .expect("failed to fetch latest block after retry")
+                        .expect("no finalized block found");
+
+                        latest = finalized.header.number;
+                        
                         if latest < next_block {
                             tokio::time::sleep(Duration::from_secs(
                                 BLOCK_SCANNER_SLEEP_TIME,

--- a/src/tree/block_scanner.rs
+++ b/src/tree/block_scanner.rs
@@ -90,7 +90,7 @@ where
                         .expect("no finalized block found");
 
                         latest = finalized.header.number;
-                        
+
                         if latest < next_block {
                             tokio::time::sleep(Duration::from_secs(
                                 BLOCK_SCANNER_SLEEP_TIME,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -31,8 +31,8 @@ use world_tree::tree::WorldTreeProvider;
 macro_rules! attempt_async {
     ($e:expr) => {
         {
-            const MAX_ATTEMPTS: usize = 10;
-            const SLEEP_DURATION: Duration = Duration::from_secs(5);
+            const MAX_ATTEMPTS: usize = 20;
+            const SLEEP_DURATION: Duration = Duration::from_secs(12);
             let mut attempt = 0;
 
             loop {


### PR DESCRIPTION
This PR lags the block stream from the block scanner behind the latest finalized block. This guarantees any Logs received through the stream will not be reorged out of the chain. 

The obvious downside here is there will be a ~72 second delay on receiving tree updates, but guarantees bad inclusion proofs will never be served in the case of a reorg on a `registerIdentities` 

Open to any feedback if we want to defer to a different approach.

Addresses [PRO-610](https://linear.app/worldcoin/issue/PRO-610/reorg-safety)
